### PR TITLE
Use imageio instead of scipy.misc which is deprecated

### DIFF
--- a/util_io.py
+++ b/util_io.py
@@ -19,7 +19,7 @@ import random
 from os.path import dirname
 
 import numpy as np
-import scipy.misc
+import imageio
 import tensorflow as tf
 from PIL import Image
 from typing import Union
@@ -132,7 +132,7 @@ def imsave(path, img):
   img = np.clip(img, 0, 255).astype(np.uint8)
   if len(img.shape) == 3 and img.shape[-1] == 1:
     img = np.squeeze(img, -1)
-  scipy.misc.imsave(path, img)
+  imageio.imwrite(path, img)
 
 
 def save_float_image(filename, img):


### PR DESCRIPTION
https://docs.scipy.org/doc/scipy-1.2.1/reference/generated/scipy.misc.imsave.html mentions deprecation. The [current](https://docs.scipy.org/doc/scipy/reference/misc.html) version of the docs does not mention `imsave` at all.