### PR TITLE
Fix `scipy.misc.imsave has been deprecated`

### DIFF
--- a/util_io.py
+++ b/util_io.py
@@ -23,6 +23,7 @@ import scipy.misc
 import tensorflow as tf
 from PIL import Image
 from typing import Union
+import imageio
 
 
 ###########
@@ -132,7 +133,7 @@ def imsave(path, img):
   img = np.clip(img, 0, 255).astype(np.uint8)
   if len(img.shape) == 3 and img.shape[-1] == 1:
     img = np.squeeze(img, -1)
-  scipy.misc.imsave(path, img)
+  imageio.imwrite(path, img)
 
 
 def save_float_image(filename, img):


### PR DESCRIPTION
scipy.misc.imsave has been deprecated in newer Scipy versions.